### PR TITLE
Extend `predicted_draws()` to handle `sim()` calls using `vars` argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tidybayes.rethinking
 Title: Tidy Data for Rethinking
-Version: 3.0.0.9000
+Version: 3.0.0
 Date: 2020-06-01
 Authors@R: c(person("Matthew", "Kay", role = c("aut", "cre"),
     email = "mjskay@northwestern.edu"))
@@ -30,7 +30,7 @@ License: GPL (>= 3)
 BugReports: https://github.com/mjskay/tidybayes.rethinking/issues/new
 URL: http://mjskay.github.io/tidybayes.rethinking, https://github.com/mjskay/tidybayes.rethinking
 VignetteBuilder: knitr
-RoxygenNote: 7.2.1
+RoxygenNote: 7.1.1
 LazyData: true
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: tidybayes.rethinking
 Title: Tidy Data for Rethinking
-Version: 3.0.0
+Version: 3.0.0.9000
 Date: 2020-06-01
 Authors@R: c(person("Matthew", "Kay", role = c("aut", "cre"),
     email = "mjskay@northwestern.edu"))
@@ -30,7 +30,7 @@ License: GPL (>= 3)
 BugReports: https://github.com/mjskay/tidybayes.rethinking/issues/new
 URL: http://mjskay.github.io/tidybayes.rethinking, https://github.com/mjskay/tidybayes.rethinking
 VignetteBuilder: knitr
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.1
 LazyData: true
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)


### PR DESCRIPTION
As issue #15 reports, `rethinking::sim(model, new_data, vars = c("foo", "bar"))` returns a named list of matrices: one for "foo" and one for "bar" as dependent variables. `predicted_draws()` expects `sim()` to return a single matrix, so `predicted_draws(model, new_data, vars = c("foo", "bar"))` throws an error.

This patch has `predicted_draws()` test for whether `sim()` returns a list, and if so, it returns a named list of data.frames, one for each matrix in the list returned by `sim()`.